### PR TITLE
Adding 2 more bytes when calculating msg_length

### DIFF
--- a/spamc/client.py
+++ b/spamc/client.py
@@ -192,7 +192,7 @@ class SpamC(object):
             try:
                 conn = self.get_connection()
                 if hasattr(msg, 'read') and hasattr(msg, 'fileno'):
-                    msg_length = str(os.fstat(msg.fileno()).st_size)
+                    msg_length = str(os.fstat(msg.fileno()).st_size + 2)
                 elif hasattr(msg, 'read'):
                     msg.seek(0, 2)
                     msg_length = str(msg.tell() + 2)


### PR DESCRIPTION
adding 2 more bytes when for the /r/n/r/n in body message when sending file descriptor for the perform method
