### PR TITLE
Python 3 compatibility (#7) and RESPONSE_RE fix (#9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - 2.6
     - 2.7
     - 3.5
+    - 3.6
 install:
     - python setup.py install
 sudo: required
@@ -23,6 +24,7 @@ before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements/requirements26_dev.txt; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install -r requirements/requirements27_dev.txt; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -r requirements/requirements3x_dev.txt; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then pip install -r requirements/requirements3x_dev.txt; fi
     - pip install codecov
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-    # - 2.6
+    - 2.6
     - 2.7
     - 3.5
 install:
@@ -8,16 +8,21 @@ install:
 sudo: required
 env:
     - SPAMD_SOCK=/var/run/spamd.sock SPAMD_COMPRESS=1
+    - ''
 script: python setup.py nosetests
 before_script:
-    - sudo apt-get update -qq
-    - sudo apt-get install spamassassin
-    - echo 'ENABLED=1' | sudo tee -a /etc/default/spamassassin
-    - echo 'OPTIONS="--listen=127.0.0.1 --socketpath=/var/run/spamd.sock --socketmode=0777 -d -l -m5"' | sudo tee -a /etc/default/spamassassin
-    - sudo service spamassassin start
+    - >-
+      if [ -n "$SPAMD_SOCK" ]; then
+      sudo apt-get update -qq &&
+      sudo apt-get install spamassassin &&
+      echo 'ENABLED=1' | sudo tee -a /etc/default/spamassassin &&
+      echo 'OPTIONS="--listen=127.0.0.1 --socketpath=/var/run/spamd.sock --socketmode=0777 -d -l -m5"' | sudo tee -a /etc/default/spamassassin &&
+      sudo service spamassassin start ;
+      fi
 before_install:
     - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install -r requirements/requirements26_dev.txt; fi
     - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then pip install -r requirements/requirements27_dev.txt; fi
+    - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then pip install -r requirements/requirements3x_dev.txt; fi
     - pip install codecov
 after_success:
     - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
     # - 2.6
     - 2.7
+    - 3.5
 install:
     - python setup.py install
 sudo: required

--- a/requirements/requirements3x_dev.txt
+++ b/requirements/requirements3x_dev.txt
@@ -1,0 +1,5 @@
+nose
+mock
+coverage
+eventlet
+gevent

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,12 @@ from setuptools import setup, find_packages
 TESTS_REQUIRE = ['nose', 'coverage', 'mock', 'eventlet', 'gevent']
 INSTALL_REQUIRES = []
 
+
 if sys.version_info < (2, 7):
     TESTS_REQUIRE.extend(['unittest2', 'importlib'])
     INSTALL_REQUIRES.append('importlib')
+if sys.version_info < (3, 0):
+    INSTALL_REQUIRES.append('future')
 
 
 def get_readme():

--- a/spamc/client.py
+++ b/spamc/client.py
@@ -23,6 +23,7 @@ import os
 import errno
 import types
 import socket
+import sys
 
 from zlib import compress
 # from mimetools import Message
@@ -68,7 +69,7 @@ def get_response(cmd, conn):
 
     raw = resp.read()
     try:
-        if hasattr(raw, 'decode'):
+        if sys.version_info >= (3,0):
             data = raw.decode()
         else:
             data = raw
@@ -117,7 +118,13 @@ def get_response(cmd, conn):
         resp_dict['message'] = ''.join(lines[4:]) + '\r\n'
     if cmd == 'HEADERS':
         parser = Parser()
-        headers = parser.parsestr('\r\n'.join(lines[4:]), headersonly=True)
+        print('get_response HEADERS response lines:', lines)
+        headerstr = '\r\n'.join(lines[4:])
+        if sys.version_info < (2, 7):
+            # Python 2.6 email parser needs plain string, not unicode
+            headerstr = str(headerstr)
+        print('get_response HEADERS headerstr:', headerstr)
+        headers = parser.parsestr(headerstr, headersonly=True)
         for key in headers.keys():
             resp_dict['headers'][key] = headers[key]
     return resp_dict

--- a/spamc/client.py
+++ b/spamc/client.py
@@ -236,7 +236,10 @@ class SpamC(object):
 
                 if isinstance(msg, str):
                     if self.gzip and msg:
-                        msg = compress(msg + '\r\n', self.compress_level)
+                        if sys.version_info >= (3,0):
+                            msg = msg.encode()
+                            headers = headers.encode()
+                        msg = compress(msg + b'\r\n', self.compress_level)
                     else:
                         msg = msg + '\r\n'
                     conn.send(headers + msg)

--- a/spamc/client.py
+++ b/spamc/client.py
@@ -69,7 +69,8 @@ def get_response(cmd, conn):
 
     raw = resp.read()
     try:
-        if sys.version_info >= (3,0):
+        # XXX Why can raw be '' (and not b''!) ???
+        if sys.version_info >= (3,0) and raw != '':
             data = raw.decode()
         else:
             data = raw

--- a/spamc/conn.py
+++ b/spamc/conn.py
@@ -72,7 +72,7 @@ class Connector(object):
 
     def send(self, data):
         "send data"
-        return self._s.sendall(data)
+        return self._s.sendall(data.encode())
 
     # def recv(self, size=1024):
     #     "receive data"

--- a/spamc/conn.py
+++ b/spamc/conn.py
@@ -73,7 +73,7 @@ class Connector(object):
 
     def send(self, data):
         "send data"
-        if sys.version_info >= (3,0):
+        if sys.version_info >= (3,0) and isinstance(data, str):
             data = data.encode()
         return self._s.sendall(data)
 
@@ -94,7 +94,9 @@ class Connector(object):
 
         while 1:
             binarydata = data.read(chunk_size)
-            if binarydata == '':
+            if sys.version_info >= (3,0):
+                binarydata = binarydata.encode()
+            if binarydata == b'':
                 break
             if zlib_compress:
                 binarydata = compressor.compress(binarydata)

--- a/spamc/conn.py
+++ b/spamc/conn.py
@@ -21,6 +21,7 @@ connections
 """
 import ssl
 import socket
+import sys
 
 from zlib import compressobj
 
@@ -72,6 +73,8 @@ class Connector(object):
 
     def send(self, data):
         "send data"
+        if sys.version_info >= (3,0):
+            data = data.encode()
         return self._s.sendall(data)
 
     # def recv(self, size=1024):

--- a/spamc/conn.py
+++ b/spamc/conn.py
@@ -72,7 +72,7 @@ class Connector(object):
 
     def send(self, data):
         "send data"
-        return self._s.sendall(data.encode())
+        return self._s.sendall(data)
 
     # def recv(self, size=1024):
     #     "receive data"

--- a/spamc/regex.py
+++ b/spamc/regex.py
@@ -25,7 +25,7 @@ import re
 BEGSP_RE = re.compile(r'^\s+\S+')
 SPACE_RE = re.compile(r'\n([\s]*)')
 RESPONSE_RE = re.compile(r'^SPAMD/(?:[0-9\.]+)\s(?P<code>[0-9]+)'
-                         r'\s(?P<message>[0-9A-Z_]+)$')
+                         r'\s(?P<message>.+)$')
 SPAM_RE = re.compile(r'^Spam:\s(?P<isspam>True|False|Yes|No)\s;'
                      r'\s(?P<score>\-?[0-9\.]+)\s\/\s(?P<basescore>[0-9\.]+)')
 DESC_RE = re.compile(r'^\s*([\S\s]*)\b\s*$')

--- a/tests/g.py
+++ b/tests/g.py
@@ -5,8 +5,8 @@ import threading
 
 import gevent
 
-from mimetools import Message
-from cStringIO import StringIO
+from email.message import Message
+from io import StringIO
 
 from gevent.pool import Pool
 from gevent.server import StreamServer

--- a/tests/test_spamc_load_backend.py
+++ b/tests/test_spamc_load_backend.py
@@ -12,7 +12,7 @@ from spamc import SpamC
 from spamc import backend_eventlet
 from spamc.exceptions import SpamCError
 
-from _s import return_tcp
+from ._s import return_tcp
 
 
 class TestSpamCTCP(unittest2.TestCase):

--- a/tests/test_spamc_mock.py
+++ b/tests/test_spamc_mock.py
@@ -13,7 +13,7 @@ import mock
 from spamc import SpamC
 from spamc.exceptions import SpamCResponseError, SpamCError
 
-from _s import return_tcp
+from ._s import return_tcp
 
 
 class TestSpamCTCP(unittest2.TestCase):

--- a/tests/test_spamc_stringio.py
+++ b/tests/test_spamc_stringio.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 import threading
@@ -8,13 +10,18 @@ except ImportError:
         raise
     import unittest as unittest2
 
-from mimetools import Message
-from cStringIO import StringIO
+
+if sys.version_info < (3, 0):
+    from cStringIO import StringIO
+    from email.parser import Parser
+else:
+    from email.parser import Parser
+    from io import StringIO
 
 from spamc import SpamC
 from spamc.exceptions import SpamCError
 
-from _s import return_tcp
+from ._s import return_tcp
 
 
 class TestSpamCTCP(unittest2.TestCase):
@@ -101,8 +108,8 @@ class TestSpamCTCP(unittest2.TestCase):
         result = self.spamc_tcp.process(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers1 = Message(headerhandle)
-        headers2 = Message(StringIO(result['message']))
+            headers1 = Parser().parse(headerhandle)
+        headers2 = Parser().parse(StringIO(result['message']))
         self.assertEqual(
             headers1.get('Subject'),
             headers2.get('Subject')
@@ -115,7 +122,8 @@ class TestSpamCTCP(unittest2.TestCase):
         result = self.spamc_tcp.headers(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers = Message(headerhandle)
+            headers = Parser().parse(headerhandle)
+            print('file_headers: ', headers)
         org_subject = "Subject: %s" % headers.get('Subject')
         new_subject = "Subject: %s" % result['headers'].get('Subject')
         self.assertEqual(org_subject, new_subject)

--- a/tests/test_spamc_stringio.py
+++ b/tests/test_spamc_stringio.py
@@ -120,6 +120,7 @@ class TestSpamCTCP(unittest2.TestCase):
             data = _handle.read()
         handle = StringIO(data)
         result = self.spamc_tcp.headers(handle)
+        print('response_headers:', result)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
             headers = Parser().parse(headerhandle)

--- a/tests/test_spamc_tcp_eventlet.py
+++ b/tests/test_spamc_tcp_eventlet.py
@@ -8,13 +8,16 @@ except ImportError:
         raise
     import unittest as unittest2
 
-from mimetools import Message
-from cStringIO import StringIO
+if sys.version_info < (3, 0):
+    from cStringIO import StringIO
+else:
+    from io import StringIO
 
+from email.parser import Parser
 from spamc import SpamC
 from spamc.exceptions import SpamCError
 
-from _s import return_tcp
+from ._s import return_tcp
 
 
 class TestSpamCTCP(unittest2.TestCase):
@@ -92,8 +95,8 @@ class TestSpamCTCP(unittest2.TestCase):
             result = self.spamc_tcp.process(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers1 = Message(headerhandle)
-        headers2 = Message(StringIO(result['message']))
+            headers1 = Parser().parse(headerhandle)
+        headers2 = Parser().parse(StringIO(result['message']))
         self.assertEqual(
             headers1.get('Subject'),
             headers2.get('Subject')
@@ -104,7 +107,7 @@ class TestSpamCTCP(unittest2.TestCase):
             result = self.spamc_tcp.headers(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers = Message(headerhandle)
+            headers = Parser().parse(headerhandle)
         org_subject = "Subject: %s" % headers.get('Subject')
         new_subject = "Subject: %s" % result['headers'].get('Subject')
         self.assertEqual(org_subject, new_subject)

--- a/tests/test_spamc_tcp_eventlet.py
+++ b/tests/test_spamc_tcp_eventlet.py
@@ -80,6 +80,7 @@ class TestSpamCTCP(unittest2.TestCase):
         self.assertIn('message', result)
         self.assertEqual('EX_OK', result['message'])
         if not self.using_sa:
+            print('report result:', repr(result))
             self.assertIn('BAYES_00', result['report'][0]['name'])
 
     def test_spamc_tcp_report_ifspam(self):

--- a/tests/test_spamc_tcp_gevent.py
+++ b/tests/test_spamc_tcp_gevent.py
@@ -8,13 +8,16 @@ except ImportError:
         raise
     import unittest as unittest2
 
-from mimetools import Message
-from cStringIO import StringIO
+if sys.version_info < (3, 0):
+    from cStringIO import StringIO
+else:
+    from io import StringIO
 
+from email.parser import Parser
 from spamc import SpamC
 from spamc.exceptions import SpamCError
 
-from _s import return_tcp
+from ._s import return_tcp
 
 
 class TestSpamCTCP(unittest2.TestCase):
@@ -92,8 +95,8 @@ class TestSpamCTCP(unittest2.TestCase):
             result = self.spamc_tcp.process(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers1 = Message(headerhandle)
-        headers2 = Message(StringIO(result['message']))
+            headers1 = Parser().parse(headerhandle)
+        headers2 = Parser().parse(StringIO(result['message']))
         self.assertEqual(
             headers1.get('Subject'),
             headers2.get('Subject')
@@ -104,7 +107,7 @@ class TestSpamCTCP(unittest2.TestCase):
             result = self.spamc_tcp.headers(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers = Message(headerhandle)
+            headers = Parser().parse(headerhandle)
         org_subject = "Subject: %s" % headers.get('Subject')
         new_subject = "Subject: %s" % result['headers'].get('Subject')
         self.assertEqual(org_subject, new_subject)

--- a/tests/test_spamc_unix.py
+++ b/tests/test_spamc_unix.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import sys
 import socket
@@ -9,15 +10,19 @@ except ImportError:
         raise
     import unittest as unittest2
 
+
 import mock
 
-from mimetools import Message
-from cStringIO import StringIO
+if sys.version_info < (3, 0):
+    from cStringIO import StringIO
+else:
+    from io import StringIO
 
+from email.parser import Parser
 from spamc import SpamC
 from spamc.exceptions import SpamCError, SpamCTimeOutError
 
-from _s import return_unix
+from ._s import return_unix
 
 
 class TestSpamCUnix(unittest2.TestCase):
@@ -113,8 +118,8 @@ class TestSpamCUnix(unittest2.TestCase):
             result = self.spamc_unix.process(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers1 = Message(headerhandle)
-        headers2 = Message(StringIO(result['message']))
+            headers1 = Parser().parse(headerhandle)
+        headers2 = Parser().parse(StringIO(result['message']))
         self.assertEqual(
             headers1.get('Subject'),
             headers2.get('Subject')
@@ -125,7 +130,7 @@ class TestSpamCUnix(unittest2.TestCase):
             result = self.spamc_unix.headers(handle)
         self.assertIn('message', result)
         with open(self.filename) as headerhandle:
-            headers = Message(headerhandle)
+            headers = Parser().parse(headerhandle)
         org_subject = "Subject: %s" % headers.get('Subject')
         new_subject = "Subject: %s" % result['headers'].get('Subject')
         self.assertEqual(org_subject, new_subject)
@@ -167,7 +172,7 @@ class TestSpamCUnix(unittest2.TestCase):
                 'bogus')
 
     def test_spamc_unix_revoke(self):
-        print self.spamc_unix.host
+        print(self.spamc_unix.host)
         with open(self.filename) as handle:
             result = self.spamc_unix.revoke(handle)
         self.assertIn('message', result)

--- a/tests/test_spamc_user.py
+++ b/tests/test_spamc_user.py
@@ -13,7 +13,7 @@ from getpass import getuser
 from spamc import SpamC
 from spamc.exceptions import SpamCError
 
-from _s import return_tcp
+from ._s import return_tcp
 
 
 class TestSpamCTCP(unittest2.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ except ImportError:
 from spamc import SpamC
 from spamc.utils import load_backend
 
-from _s import return_unix
+from ._s import return_unix
 
 
 class TestSpamCUtils(unittest2.TestCase):


### PR DESCRIPTION
## Python 3 Compat (#7)

The main work is in getting the tests to work. Since `mimetools` is gone, I had to implement my own "headers only" pre-parser (`parse_headers` in `_s.py`). Also, the `do_HEADERS` function got a rewrite.

Testing was only done using the unit tests against Python 3.6.0 and Python 2.7.13 (arch linux package versions). I still have to do testing against a real spamd.

Compatibility with Python < 2.7 is probably no longer present (e.g. because `b` prefix for bytestrings is used now).

## RESPONSE_RE (#9)

Just like discussed in #9.


Fixes #7.
Fixes #9.